### PR TITLE
Fixes #26 - Debug Table arrays w/o separators.

### DIFF
--- a/CYLGame/www/static/player.js
+++ b/CYLGame/www/static/player.js
@@ -438,9 +438,18 @@ class Player {
     let row = $("<tr>").append($("<th>").html("Name")).append($("<th>").html("Value"));
     this.debug_table.html("").append(row);
     keys.forEach((item, index) => {
-        let row = $("<tr>").append($("<td>").html(item)).append($("<td>").html(vars[item]));
+        let value = this.var_to_string(vars[item]);
+        let row = $("<tr>").append($("<td>").html(item)).append($("<td>")
+            .text(value));
         this.debug_table.append(row);
     });
+  }
+
+  var_to_string(value) {
+    if (Array.isArray(value)) {
+      return "[" + value.map((val) => {return this.var_to_string(val);}).join(",") + "]"
+    }
+    return value.toString();
   }
 }
 


### PR DESCRIPTION
Example Code:
```
foo = []
foo[0] = 1
foo[1] = 2
foo[4] = [3,4]
```

How it was displayed in the debug table:

Before:
```
foo | 12003,4
```

After:
```
foo | [1,2,0,0,[3,4]]
```