### PR TITLE
Closes #29 - Save all programs that users run

### DIFF
--- a/CYLGame/Comp.py
+++ b/CYLGame/Comp.py
@@ -30,7 +30,7 @@ def create_room(gamedb, bot, compiler, size):
     bots = [bot]
     while True:
         token = choice(pool)
-        code, options = gamedb.get_code_and_options(token)
+        code, options = gamedb.get_active_code_and_options(token)
         try:
             prog = compiler.compile(code)
             prog.options = options
@@ -251,7 +251,7 @@ class MultiplayerComp(object):
         try:
             if debug:
                 print("Making bot for '" + token + "'")
-            code, options = gamedb.get_code_and_options(token)
+            code, options = gamedb.get_active_code_and_options(token)
             name = gamedb.get_name(token)
             if not code:
                 return
@@ -513,7 +513,7 @@ class RollingMultiplayerCompRunner(Process):
         try:
             if self.debug:
                 print("Making bot for '" + token + "'")
-            code, options = self.gamedb.get_code_and_options(token)
+            code, options = self.gamedb.get_active_code_and_options(token)
             name = self.gamedb.get_name(token)
             if not code:
                 return

--- a/CYLGame/Database.py
+++ b/CYLGame/Database.py
@@ -110,16 +110,11 @@ class GameDB(object):
         self.__load()
 
     def __load(self):
-        if not os.path.exists(self.root_dir):
-            os.mkdir(self.root_dir)
-        if not os.path.exists(self.game_dir):
-            os.mkdir(self.game_dir)
-        if not os.path.exists(self.data_dir):
-            os.mkdir(self.data_dir)
-        if not os.path.exists(self.schools_dir):
-            os.mkdir(self.schools_dir)
-        if not os.path.exists(self.competitions_dir):
-            os.mkdir(self.competitions_dir)
+        os.makedirs(self.root_dir, exist_ok=True)
+        os.makedirs(self.game_dir, exist_ok=True)
+        os.makedirs(self.data_dir, exist_ok=True)
+        os.makedirs(self.schools_dir, exist_ok=True)
+        os.makedirs(self.competitions_dir, exist_ok=True)
 
     def __get_user_tokens(self):
         return os.listdir(self.data_dir)
@@ -218,8 +213,8 @@ class GameDB(object):
             pass
 
         # Create token dir
-        os.mkdir(os.path.join(self.data_dir, token))
-        os.mkdir(os.path.join(self.data_dir, token, "games"))
+        os.makedirs(os.path.join(self.data_dir, token))
+        os.makedirs(os.path.join(self.data_dir, token, "games"))
         return token
 
     def add_new_school(self, name="", _token=None):  # Don't use `_token` unless you know what you are doing.
@@ -227,8 +222,8 @@ class GameDB(object):
         if _token is None:
             token = self.__get_new_token(self.__get_school_tokens(), prefix="S")
 
-        os.mkdir(os.path.join(self.schools_dir, token))
-        os.mkdir(os.path.join(self.schools_dir, token, "tokens"))
+        os.makedirs(os.path.join(self.schools_dir, token))
+        os.makedirs(os.path.join(self.schools_dir, token, "tokens"))
 
         with io.open(os.path.join(self.schools_dir, token, "name"), "w", encoding="utf8") as fp:
             fp.write(text(name))
@@ -240,9 +235,9 @@ class GameDB(object):
         if token is None:
             token = self.__get_new_token(self.__get_comp_tokens(), prefix="P")
 
-        os.mkdir(os.path.join(self.competitions_dir, token))
-        os.mkdir(os.path.join(self.competitions_dir, token, "schools"))
-        os.mkdir(os.path.join(self.competitions_dir, token, "games"))
+        os.makedirs(os.path.join(self.competitions_dir, token))
+        os.makedirs(os.path.join(self.competitions_dir, token, "schools"))
+        os.makedirs(os.path.join(self.competitions_dir, token, "games"))
 
         with io.open(os.path.join(self.competitions_dir, token, "name"), "w", encoding="utf8") as fp:
             fp.write(text(name))
@@ -257,8 +252,8 @@ class GameDB(object):
 
         token = self.__get_new_token(self.__get_game_tokens(), prefix="G")
 
-        os.mkdir(os.path.join(self.game_dir, token))
-        os.mkdir(os.path.join(self.game_dir, token, "players"))
+        os.makedirs(os.path.join(self.game_dir, token))
+        os.makedirs(os.path.join(self.game_dir, token, "players"))
 
         if frames is not None:
             self.save_game_frames(token, frames)
@@ -281,7 +276,7 @@ class GameDB(object):
 
         school_dir = self.__get_dir_for_token(ctoken, ["schools", stoken])
         if not os.path.exists(school_dir):
-            os.mkdir(school_dir)
+            os.makedirs(school_dir)
 
     # TODO(derpferd): add function to remove a school
 
@@ -291,7 +286,7 @@ class GameDB(object):
 
         school_dir = self.__get_dir_for_token(ctoken, ["schools", stoken])
         if not os.path.exists(school_dir):
-            os.mkdir(school_dir)
+            os.makedirs(school_dir)
 
         with io.open(os.path.join(school_dir, "code.lp"), "w", encoding="utf8") as fp:
             fp.write(text(code))
@@ -303,7 +298,7 @@ class GameDB(object):
     #
     #     school_dir = self.__get_dir_for_token(ctoken, ["schools", stoken])
     #     if not os.path.exists(school_dir):
-    #         os.mkdir(school_dir)
+    #         os.makedirs(school_dir)
     #     with io.open(os.path.join(school_dir, "code.lp"), "w", encoding="utf8") as fp:
     #         code = self.get_code(utoken)
     #         assert code is not None
@@ -376,7 +371,7 @@ class GameDB(object):
         buf.seek(0)
         code_hash = hash_stream(buf)
         code_path_name = f"{ctime}_{code_hash}"
-        os.mkdir(os.path.join(code_dir, code_path_name))
+        os.makedirs(os.path.join(code_dir, code_path_name))
 
         # Write code
         with io.open(os.path.join(code_dir, code_path_name, self.CODE_FILENAME), "w", encoding="utf8") as fp:
@@ -444,10 +439,10 @@ class GameDB(object):
         assert os.path.exists(self.__get_dir_for_token(gtoken, "players"))
         assert self.is_user_token(token), "Token '{}' must be a user token".format(token)
         if not os.path.exists(self.__get_dir_for_token(token, "games")):
-            os.mkdir(self.__get_dir_for_token(token, "games"))
+            os.makedirs(self.__get_dir_for_token(token, "games"))
         assert os.path.exists(self.__get_dir_for_token(token, "games")), "Player token must have a games directory."
 
-        os.mkdir(self.__get_dir_for_token(gtoken, ["players", token]))
+        os.makedirs(self.__get_dir_for_token(gtoken, ["players", token]))
 
         write_json(data, self.__get_dir_for_token(gtoken, ["players", token, "data.mp.gz"]))
 
@@ -462,7 +457,7 @@ class GameDB(object):
         os.remove(self.__get_dir_for_token(ctoken, ["games", gtoken]))
 
     def replace_games_in_comp(self, ctoken, new_gtokens, cleanup=True):
-        os.mkdir(os.path.join(self.competitions_dir, ctoken, "new_games"))
+        os.makedirs(os.path.join(self.competitions_dir, ctoken, "new_games"))
         for gtoken in new_gtokens:
             with open(self.__get_dir_for_token(ctoken, ["new_games", gtoken]), "w"):
                 pass

--- a/CYLGame/Database.py
+++ b/CYLGame/Database.py
@@ -70,6 +70,23 @@ class WWWCache:
 
 # TODO(derpferd): Use the move function to prevent RACE on files
 class GameDB(object):
+    """
+    This is the database that stores all persisted data. This database is a file based DB.
+
+    /                           => Root game directory
+    /data                       => Should be named something like "users". This stores user related data.
+    /data/TOKEN                 => A directory containing data for the user with the token TOKEN.
+    /data/TOKEN/avg_score       => File containing a single float representing the average score for the user.
+    /data/TOKEN/name            => File containing the name for the user.
+    /data/TOKEN/code.lp         => The last code submitted for the user.
+    /data/TOKEN/games           => A directory related games.
+    /data/TOKEN/games/GTOKEN    => An empty file representing that the users bot was used in game GTOKEN.
+    /games                      => Stores game related data.
+    /schools                    => Stores school related data.
+    /competitions               => Stores competition related data.
+    /www                        => Stores static and template files for the server. This is a cache that is deleted and
+                                    recreated on each restart.
+    """
     TOKEN_LEN = 8
 
     def __init__(self, root_dir):

--- a/CYLGame/Database.py
+++ b/CYLGame/Database.py
@@ -275,8 +275,7 @@ class GameDB(object):
         assert self.is_school_token(stoken)
 
         school_dir = self.__get_dir_for_token(ctoken, ["schools", stoken])
-        if not os.path.exists(school_dir):
-            os.makedirs(school_dir)
+        os.makedirs(school_dir, exist_ok=True)
 
     # TODO(derpferd): add function to remove a school
 
@@ -285,8 +284,7 @@ class GameDB(object):
         assert self.is_school_token(stoken)
 
         school_dir = self.__get_dir_for_token(ctoken, ["schools", stoken])
-        if not os.path.exists(school_dir):
-            os.makedirs(school_dir)
+        os.makedirs(school_dir, exist_ok=True)
 
         with io.open(os.path.join(school_dir, "code.lp"), "w", encoding="utf8") as fp:
             fp.write(text(code))
@@ -359,11 +357,10 @@ class GameDB(object):
         """
         assert os.path.exists(self.__get_dir_for_token(token))
         code_dir = self.__get_dir_for_token(token, self.CODE_DIR)
-        if not os.path.exists(code_dir):
-            os.makedirs(code_dir, exist_ok=True)
+        os.makedirs(code_dir, exist_ok=True)
 
         # Create Code id.
-        ctime = int(time.time())
+        ctime = int(time.time_ns())
         buf = io.BytesIO()
         buf.write(bytes(code, encoding='utf8'))
         if options:
@@ -371,7 +368,10 @@ class GameDB(object):
         buf.seek(0)
         code_hash = hash_stream(buf)
         code_path_name = f"{ctime}_{code_hash}"
-        os.makedirs(os.path.join(code_dir, code_path_name))
+        try:
+            os.makedirs(os.path.join(code_dir, code_path_name))
+        except OSError:
+            raise ValueError("Duplicate Request!")
 
         # Write code
         with io.open(os.path.join(code_dir, code_path_name, self.CODE_FILENAME), "w", encoding="utf8") as fp:
@@ -438,8 +438,7 @@ class GameDB(object):
     def set_game_player(self, gtoken, token, data=None):
         assert os.path.exists(self.__get_dir_for_token(gtoken, "players"))
         assert self.is_user_token(token), "Token '{}' must be a user token".format(token)
-        if not os.path.exists(self.__get_dir_for_token(token, "games")):
-            os.makedirs(self.__get_dir_for_token(token, "games"))
+        os.makedirs(self.__get_dir_for_token(token, "games"), exist_ok=True)
         assert os.path.exists(self.__get_dir_for_token(token, "games")), "Player token must have a games directory."
 
         os.makedirs(self.__get_dir_for_token(gtoken, ["players", token]))

--- a/CYLGame/Server.py
+++ b/CYLGame/Server.py
@@ -215,6 +215,7 @@ class GameServer(flask_classful.FlaskView):
     def sim(self):
         code = flask.request.get_json(silent=True).get('code', '')
         seed_str = flask.request.get_json(silent=True).get('seed', '')
+        token = flask.request.get_json(silent=True).get('token', '').upper()
         opponents = flask.request.get_json(silent=True).get('opponents', None)
         options = flask.request.get_json(silent=True).get('options', None)
         if options is None:
@@ -232,6 +233,8 @@ class GameServer(flask_classful.FlaskView):
             prog.name = "Your bot"
         except:
             return flask.jsonify(error="Code did not compile")
+        if self.gamedb.is_user_token(token):
+            self.gamedb.save_code(token=token, code=code, options=options, set_as_active=False)
         room = Room(bots=[prog], seed=seed)
         if self.game.MULTIPLAYER:
             players = []
@@ -275,7 +278,7 @@ class GameServer(flask_classful.FlaskView):
         if not self.gamedb.is_user_token(token):
             return flask.jsonify(error="Invalid Token")
         else:
-            code, options = self.gamedb.get_code_and_options(token)
+            code, options = self.gamedb.get_active_code_and_options(token)
             return flask.jsonify(code=code, options=options)
 
     @flask_classful.route('/play', methods=['POST'])

--- a/CYLGame/Utils.py
+++ b/CYLGame/Utils.py
@@ -1,5 +1,7 @@
 from __future__ import division
 
+import hashlib
+import io
 import math
 import string
 import warnings
@@ -118,3 +120,21 @@ def deprecated(message=""):
             return func(*args, **kwargs)
         return new_func
     return deprecated_decorator
+
+
+def hash_string(s, encoding='utf8'):
+    buf = io.BytesIO()
+    buf.write(bytes(s, encoding=encoding))
+    buf.seek(0)
+    return hash_stream(buf)
+
+
+def hash_stream(fp):
+    BUF_SIZE = 65536
+    sha = hashlib.sha1()
+    while True:
+        data = fp.read(BUF_SIZE)
+        if not data:
+            break
+        sha.update(data)
+    return sha.hexdigest()

--- a/CYLGame/Utils.py
+++ b/CYLGame/Utils.py
@@ -131,7 +131,7 @@ def hash_string(s, encoding='utf8'):
 
 def hash_stream(fp):
     BUF_SIZE = 65536
-    sha = hashlib.sha1()
+    sha = hashlib.sha256()
     while True:
         data = fp.read(BUF_SIZE)
         if not data:

--- a/CYLGame/www/templates/grid.html
+++ b/CYLGame/www/templates/grid.html
@@ -136,11 +136,17 @@
             });
         }
         function testCode(opponents) {
+            let token_value;
+            if (!localStorage.user_token) {
+                token_value = "";
+            } else {
+                token_value = localStorage.user_token;
+            }
             $("#debugTable").html("");
             $.ajax({
                 type: "POST",
                 url: $SCRIPT_ROOT + 'sim',
-                data: JSON.stringify({code: editor.getValue(), seed: window.seed, opponents: opponents}),
+                data: JSON.stringify({code: editor.getValue(), token:token_value, seed: window.seed, opponents: opponents}),
                 contentType: "application/json; charset=utf-8",
                 dataType: "json",
                 success: function(data) {


### PR DESCRIPTION
This PR changes how and when users' programs are saved.

Original logic:
 - Every time a user clicks `submit` the current user program is sent to the server.
 - The server compiles and runs the user program.
 - The server saves the program for the user overwriting previous program.
 - When scoring programs the db simply reads the code file.

New logic
 - Each time a user hits the `play` or `submit` button program is sent to the server.
 - The server compiles and runs the user program.
 - The server saves the program using a timestamp and hash in a new directory.
 - If the request was a submit request the server marks the newly saved program as the `active` program.
 - When scoring programs the db finds which code is active then reads from that directory.

The feature by itself isn't user facing but it enables many new cool user facing features like #30, viewing older versions, allowing users to save multiple programs and selecting the one with the highest score, etc... 